### PR TITLE
Add ActiveProfiles to CardIntegrationTest

### DIFF
--- a/src/test/java/com/qa/sppd/card/CardIntegrationTest.java
+++ b/src/test/java/com/qa/sppd/card/CardIntegrationTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @AutoConfigureMockMvc
 @Sql(scripts={"classpath:card-schema.sql", "classpath:card-data.sql"},
         executionPhase=Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@ActiveProfiles("test")
 public class CardIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
Running integration testing is dropping MySQL table and creates new based on the test schema